### PR TITLE
deps: add papermill for parameters in jupyter

### DIFF
--- a/.github/.devcontainer/quarto-computing-dependencies/install.sh
+++ b/.github/.devcontainer/quarto-computing-dependencies/install.sh
@@ -37,7 +37,7 @@ quarto_r_deps() {
 }
 
 quarto_python_deps() {
-  su "${USERNAME}" -c "python3 -m pip install jupyter"
+  su "${USERNAME}" -c "python3 -m pip install jupyter papermill"
 }
 
 quarto_julia_deps() {


### PR DESCRIPTION
This pull request includes a small change to the `quarto_python_deps()` function in the `.github/.devcontainer/quarto-computing-dependencies/install.sh` file. The change ensures that the `papermill` package is installed alongside `jupyter` to allow to use parameters in Quarto.

* `quarto_python_deps()` function in `.github/.devcontainer/quarto-computing-dependencies/install.sh`: Added installation of the `papermill` package.