### PR TITLE
deps: add Jupyter VSCode extension to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,8 @@
 				"ms-python.flake8",
 				"ms-python.vscode-pylance",
 				"ms-python.pylint",
-				"ms-python.isort"
+				"ms-python.isort",
+				"ms-toolsai.jupyter"
 			],
 			"settings": {
 				"r.rterm.option": [


### PR DESCRIPTION
Include the Jupyter extension in the development container configuration to enhance support for Jupyter notebooks.