### PR TITLE
fix: global installation of UV

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
 ARG VARIANT="jammy"
-FROM buildpack-deps:${VARIANT}-curl
+FROM --platform=linux/amd64 buildpack-deps:${VARIANT}-curl

--- a/.github/.devcontainer/uv/install.sh
+++ b/.github/.devcontainer/uv/install.sh
@@ -49,12 +49,11 @@ install_uv() {
   local version=$1
   local url="https://github.com/astral-sh/uv/releases/${version}/download/uv-installer.sh"
   check_packages curl ca-certificates
-  su "${USERNAME}" -c "curl --proto '=https' --tlsv1.2 -LsSf ${url} | sh"
+  curl --proto '=https' --tlsv1.2 -LsSf ${url} | env UV_INSTALL_DIR="/usr/local/bin" sh
 }
 
 enable_autocompletion() {
-  su "${USERNAME}" -c "echo 'eval \"\$(uv generate-shell-completion zsh)\"' >> \"\$HOME/.zshrc\""
-  su "${USERNAME}" -c "echo 'eval \"\$(uvx --generate-shell-completion zsh)\"' >> \"\$HOME/.zshrc\""
+  echo 'eval "$(uv generate-shell-completion zsh)"' >> /usr/share/zsh/vendor-completions/_uv
 }
 
 install_uv ${VERSION}


### PR DESCRIPTION
Ensure the UV installer script installs globally by setting the installation directory to `/usr/local/bin`. Update the Dockerfile to support the installation on the specified platform. Adjust autocompletion setup to write directly to the vendor completions directory.