### PR TITLE
deps: Use GitHub release for httpgd dependency

### DIFF
--- a/init-env.sh
+++ b/init-env.sh
@@ -17,7 +17,7 @@ initialise_r() {
       sed -i '' '/source("renv\/activate.R")/d' .Rprofile
     fi
     Rscript -e 'renv::init(bare = FALSE)'
-    Rscript -e 'renv::install(c("rmarkdown", "prompt", "languageserver", "lintr", "styler", "cli"))'
+    Rscript -e 'renv::install(c("rmarkdown", "languageserver", "nx10/httpgd@v2.0.3", "prompt", "lintr", "cli"))'
     Rscript -e 'renv::snapshot(type = "all")'
   fi
 }


### PR DESCRIPTION
Update the `init-env.sh` script to install the `httpgd` package from the GitHub release, ensuring the project uses a specific version for better stability and compatibility without the issue of CRAN archiving the package.