### PR TITLE
deps: Bump Quarto to version 1.7.30 in devcontainer setup

### DIFF
--- a/.devcontainer/mcanouil-1.7.30/devcontainer.json
+++ b/.devcontainer/mcanouil-1.7.30/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.7.29 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.7.30 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.7.29",
+			"version": "1.7.30",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}


### PR DESCRIPTION
Update the devcontainer configuration to use Quarto version 1.7.30, enhancing the development environment for improved functionality and compatibility.