### PR TITLE
refactor: change directory structure by removing patch versions

### DIFF
--- a/.devcontainer/mcanouil-1.0/devcontainer.json
+++ b/.devcontainer/mcanouil-1.0/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.7.30 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.0 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.7.30",
+			"version": "1.0.38",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.1/devcontainer.json
+++ b/.devcontainer/mcanouil-1.1/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.0.38 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.1 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.0.38",
+			"version": "1.1.189",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.2/devcontainer.json
+++ b/.devcontainer/mcanouil-1.2/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "1.2.475 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.2 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {

--- a/.devcontainer/mcanouil-1.3/devcontainer.json
+++ b/.devcontainer/mcanouil-1.3/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.4.557 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.3 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.4.557",
+			"version": "1.3.450",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.4/devcontainer.json
+++ b/.devcontainer/mcanouil-1.4/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.1.189 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.4 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.1.189",
+			"version": "1.4.557",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.5/devcontainer.json
+++ b/.devcontainer/mcanouil-1.5/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "1.5.57 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.5 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {

--- a/.devcontainer/mcanouil-1.6/devcontainer.json
+++ b/.devcontainer/mcanouil-1.6/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.3.450 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.6 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.3.450",
+			"version": "1.6.42",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.7/devcontainer.json
+++ b/.devcontainer/mcanouil-1.7/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "1.6.42 - Mickaël CANOUIL - Quarto Codespaces",
+	"name": "1.7 - Mickaël CANOUIL - Quarto Codespaces",
 	"image": "ghcr.io/mcanouil/quarto-codespaces:latest",
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.6.42",
+			"version": "1.7.30",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}


### PR DESCRIPTION
Remove patch version numbers from directory names to simplify the structure and improve clarity. This change enhances maintainability and consistency across the project.