### PR TITLE
fix: update quarto-cli versions to remove patch numbers

### DIFF
--- a/.devcontainer/mcanouil-1.0/devcontainer.json
+++ b/.devcontainer/mcanouil-1.0/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.0.38",
+			"version": "1.0",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.1/devcontainer.json
+++ b/.devcontainer/mcanouil-1.1/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.1.189",
+			"version": "1.1",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.2/devcontainer.json
+++ b/.devcontainer/mcanouil-1.2/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.2.475",
+			"version": "1.2",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.3/devcontainer.json
+++ b/.devcontainer/mcanouil-1.3/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.3.450",
+			"version": "1.3",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.4/devcontainer.json
+++ b/.devcontainer/mcanouil-1.4/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.4.557",
+			"version": "1.4",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.5/devcontainer.json
+++ b/.devcontainer/mcanouil-1.5/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.5.57",
+			"version": "1.5",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.6/devcontainer.json
+++ b/.devcontainer/mcanouil-1.6/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.6.42",
+			"version": "1.6",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}

--- a/.devcontainer/mcanouil-1.7/devcontainer.json
+++ b/.devcontainer/mcanouil-1.7/devcontainer.json
@@ -4,7 +4,7 @@
 	"remoteUser": "vscode",
 	"features": {
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-			"version": "1.7.30",
+			"version": "1.7",
 			"installTinyTex": "false",
 			"installChromium": "false"
 		}


### PR DESCRIPTION
Update the versions of quarto-cli in the devcontainer configurations to remove patch numbers, ensuring a cleaner versioning approach.