### PR TITLE
feat: Add multiple Quarto Codespaces configurations

### DIFF
--- a/.devcontainer/quarto-1.0/devcontainer.json
+++ b/.devcontainer/quarto-1.0/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "Latest - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.0 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "prerelease"
+      "version": "1.0"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.1/devcontainer.json
+++ b/.devcontainer/quarto-1.1/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.5 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.1 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.5"
+      "version": "1.1"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.2/devcontainer.json
+++ b/.devcontainer/quarto-1.2/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.0 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.2 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.0"
+      "version": "1.2"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.3/devcontainer.json
+++ b/.devcontainer/quarto-1.3/devcontainer.json
@@ -1,10 +1,10 @@
 {
-  "name": "Release - Quarto Codespaces",
+  "name": "1.3 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "release"
+      "version": "1.3"
     }
   },
   "customizations": {

--- a/.devcontainer/quarto-1.4/devcontainer.json
+++ b/.devcontainer/quarto-1.4/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.6 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.4 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.6"
+      "version": "1.4"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.5/devcontainer.json
+++ b/.devcontainer/quarto-1.5/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.2 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.5 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.2"
+      "version": "1.5"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.6/devcontainer.json
+++ b/.devcontainer/quarto-1.6/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.7 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.6 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.7"
+      "version": "1.6"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.7/devcontainer.json
+++ b/.devcontainer/quarto-1.7/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.3 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.7 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.3"
+      "version": "1.7"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-1.8/devcontainer.json
+++ b/.devcontainer/quarto-1.8/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.4 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "1.8 - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.4"
+      "version": "1.8"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",

--- a/.devcontainer/quarto-prerelease/devcontainer.json
+++ b/.devcontainer/quarto-prerelease/devcontainer.json
@@ -1,33 +1,13 @@
 {
-  "name": "1.1 - Mickaël CANOUIL - Quarto Codespaces",
+  "name": "Pre-release - Quarto Codespaces",
   "image": "ghcr.io/mcanouil/quarto-codespaces:latest",
   "remoteUser": "vscode",
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
-      "version": "1.1"
+      "version": "prerelease"
     }
   },
   "customizations": {
-    "codespaces": {
-      "repositories": {
-        "mcanouil/quarto-codespaces": {
-          "permissions": {
-            "contents": "write",
-            "pull_requests": "write"
-          }
-        },
-        "mcanouil/quarto-issues-experiments": {
-          "permissions": {
-            "contents": "write"
-          }
-        },
-        "mcanouil/*": {
-          "permissions": {
-            "contents": "read"
-          }
-        }
-      }
-    },
     "vscode": {
       "extensions": [
         "quarto.quarto",


### PR DESCRIPTION
Introduce new development container configurations for Quarto versions 1.0 to 1.8 and a pre-release version, enabling users to easily switch between different Quarto versions in their development environment.

Remove all configuration for custom repository permissions not really used.