### PR TITLE
deps: update Dockerfile base image to Ubuntu Noble 24.04

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG IMAGE="buildpack-deps:jammy-curl"
+ARG IMAGE="buildpack-deps:noble-curl"
 FROM ${IMAGE}


### PR DESCRIPTION
Change the base image in the Dockerfile to 'buildpack-deps:noble-curl' for improved compatibility.