### PR TITLE
fix: repair setup scripts and harden installer downloads

### DIFF
--- a/.devcontainer/universal/uv/install.sh
+++ b/.devcontainer/universal/uv/install.sh
@@ -4,30 +4,11 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
-
 VERSION=${VERSION:-"latest"}
 
 if [ "$(id -u)" -ne 0 ]; then
   echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
   exit 1
-fi
-
-# Determine the appropriate non-root user
-if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
-  USERNAME=""
-  POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-  for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-    if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-      USERNAME=${CURRENT_USER}
-      break
-    fi
-  done
-  if [ "${USERNAME}" = "" ]; then
-    USERNAME=root
-  fi
-elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
-  USERNAME=root
 fi
 
 apt_get_update() {
@@ -47,7 +28,12 @@ check_packages() {
 
 install_uv() {
   local version=$1
-  local url="https://github.com/astral-sh/uv/releases/${version}/download/uv-installer.sh"
+  local url
+  if [ "${version}" = "latest" ]; then
+    url="https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh"
+  else
+    url="https://github.com/astral-sh/uv/releases/download/${version}/uv-installer.sh"
+  fi
   check_packages curl ca-certificates
   curl --proto '=https' --tlsv1.2 -LsSf "${url}" | env UV_INSTALL_DIR="/usr/local/bin" sh
 }

--- a/.github/.devcontainer/chrome/install.sh
+++ b/.github/.devcontainer/chrome/install.sh
@@ -4,10 +4,6 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
-
-VERSION=${VERSION:-"22"}
-
 if [ "$(id -u)" -ne 0 ]; then
   echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
   exit 1
@@ -17,23 +13,6 @@ arch="$(dpkg --print-architecture)"
 if [ "${arch}" != "amd64" ] && [ "${arch}" != "arm64" ]; then
   echo "Architecture ${arch} unsupported"
   exit 2
-fi
-
-# Determine the appropriate non-root user
-if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
-  USERNAME=""
-  POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-  for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-    if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-      USERNAME=${CURRENT_USER}
-      break
-    fi
-  done
-  if [ "${USERNAME}" = "" ]; then
-    USERNAME=root
-  fi
-elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
-  USERNAME=root
 fi
 
 apt_get_update() {
@@ -54,8 +33,8 @@ check_packages() {
 install_chrome() {
   local arch="$1"
   check_packages curl gnupg
-  curl -fSsL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/google-chrome.gpg >>/dev/null
-  echo "deb [arch=${arch} signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
+  curl --proto '=https' --tlsv1.2 -fSsL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /usr/share/keyrings/google-chrome.gpg >>/dev/null
+  echo "deb [arch=${arch} signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | tee /etc/apt/sources.list.d/google-chrome.list
   apt_get_update
   check_packages google-chrome-stable
 }

--- a/.github/.devcontainer/decktape/devcontainer-feature.json
+++ b/.github/.devcontainer/decktape/devcontainer-feature.json
@@ -4,7 +4,7 @@
   "name": "decktape",
   "description": "Install decktape, a tool for generating PDFs from web pages.",
   "options": {
-    "node": {
+    "version": {
       "default": "22",
       "description": "Select the Node version to install.",
       "proposals": ["22"],

--- a/.github/.devcontainer/decktape/install.sh
+++ b/.github/.devcontainer/decktape/install.sh
@@ -4,30 +4,11 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
-
 VERSION=${VERSION:-"22"}
 
 if [ "$(id -u)" -ne 0 ]; then
   echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
   exit 1
-fi
-
-# Determine the appropriate non-root user
-if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
-  USERNAME=""
-  POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-  for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-    if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-      USERNAME=${CURRENT_USER}
-      break
-    fi
-  done
-  if [ "${USERNAME}" = "" ]; then
-    USERNAME=root
-  fi
-elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
-  USERNAME=root
 fi
 
 apt_get_update() {

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -61,7 +61,7 @@
     },
     "./chrome": {},
     "./decktape": {
-      "node": "22"
+      "version": "22"
     },
     "./tinytex": {},
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {

--- a/.github/.devcontainer/tinytex/install.sh
+++ b/.github/.devcontainer/tinytex/install.sh
@@ -54,7 +54,7 @@ install_tinytex() {
   check_packages libfontconfig
   # su "${USERNAME}" -c 'quarto install tinytex --quiet'
   check_packages curl ca-certificates
-  curl -sL "https://yihui.org/tinytex/install-bin-unix.sh" | sh
+  curl --proto '=https' --tlsv1.2 -fsSL "https://yihui.org/tinytex/install-bin-unix.sh" | sh
   TINYTEX_OPT="/opt/tinytex"
   mv /root/.TinyTeX "${TINYTEX_OPT}"
   TINYTEX_INSTALL_DIR="${TINYTEX_OPT}/bin/$(uname -m)-linux"

--- a/.github/.devcontainer/uv/install.sh
+++ b/.github/.devcontainer/uv/install.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
-
 VERSION=${VERSION:-"latest"}
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -17,23 +15,6 @@ architecture="$(dpkg --print-architecture)"
 if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "arm64" ]; then
   echo "(!) Architecture ${architecture} unsupported"
   exit 2
-fi
-
-# Determine the appropriate non-root user
-if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
-  USERNAME=""
-  POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
-  for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do
-    if id -u "${CURRENT_USER}" >/dev/null 2>&1; then
-      USERNAME=${CURRENT_USER}
-      break
-    fi
-  done
-  if [ "${USERNAME}" = "" ]; then
-    USERNAME=root
-  fi
-elif [ "${USERNAME}" = "none" ] || ! id -u "${USERNAME}" >/dev/null 2>&1; then
-  USERNAME=root
 fi
 
 apt_get_update() {
@@ -53,7 +34,12 @@ check_packages() {
 
 install_uv() {
   local version=$1
-  local url="https://github.com/astral-sh/uv/releases/${version}/download/uv-installer.sh"
+  local url
+  if [ "${version}" = "latest" ]; then
+    url="https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh"
+  else
+    url="https://github.com/astral-sh/uv/releases/download/${version}/uv-installer.sh"
+  fi
   check_packages curl ca-certificates
   curl --proto '=https' --tlsv1.2 -LsSf "${url}" | env UV_INSTALL_DIR="/usr/local/bin" sh
 }

--- a/init-env.sh
+++ b/init-env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 show_help() {
   echo "Usage: $0 [--what/-w all|r|python|julia] [--force/-f] [--help/-h]"
   echo "  --what/-w: Specify what to initialise (default: all)."
@@ -13,10 +15,10 @@ show_help() {
 
 initialise_r() {
   local deps=$1
-  deps=$(echo "${deps}" | sed 's/,/","/g')
+  deps=${deps//,/\",\"}
   if [ "${FORCE}" = true ] || [ ! -f "renv.lock" ]; then
     if [ -f ".Rprofile" ] && grep -q 'source("renv/activate.R")' .Rprofile; then
-      sed -i '' '/source("renv\/activate.R")/d' .Rprofile
+      sed -i.bak '/source("renv\/activate.R")/d' .Rprofile && rm -f .Rprofile.bak
     fi
     Rscript -e 'renv::init(bare = FALSE)'
     Rscript -e "renv::install(c('${deps}'))"
@@ -24,24 +26,15 @@ initialise_r() {
   fi
 }
 
-initialise_python() {
-  local deps=$1
-  deps=$(echo "${deps}" | sed 's/,/ /g')
-  if [ "${FORCE}" = true ] || [ ! -f "requirements.txt" ]; then
-    python3 -m venv .venv
-    source .venv/bin/activate
-    python3 -m pip install ${deps}
-    python3 -m pip freeze > requirements.txt
-  fi
-}
-
 initialise_uv() {
   local deps=$1
-  deps=$(echo "${deps}" | sed 's/,/ /g')
+  deps=${deps//,/ }
   if [ "${FORCE}" = true ] || [ ! -f "uv.lock" ]; then
     uv init --no-package --vcs none --bare --no-readme --author-from none
     uv venv
+    # shellcheck disable=SC1091
     source .venv/bin/activate
+    # shellcheck disable=SC2086
     uv add ${deps}
     uv sync
   fi
@@ -49,7 +42,7 @@ initialise_uv() {
 
 initialise_julia() {
   local deps=$1
-  deps=$(echo "${deps}" | sed 's/,/","/g')
+  deps=${deps//,/\",\"}
   if [ "${FORCE}" = true ] || [ ! -f "Project.toml" ]; then
     julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate()'
     julia --project=. -e "using Pkg; Pkg.add([\"${deps}\"])"
@@ -61,14 +54,14 @@ FORCE=false
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
-    --what|-w)
+    --what | -w)
       WHAT="$2"
       shift
       ;;
-    --force|-f)
+    --force | -f)
       FORCE=true
       ;;
-    --help|-h)
+    --help | -h)
       show_help
       exit 0
       ;;


### PR DESCRIPTION
Fixes the BSD-only `sed -i ''` call in `init-env.sh` that fails on Linux, adds `set -euo pipefail`, removes the unused `initialise_python` function, and replaces `sed`-based substitutions with bash parameter expansion.
Renames the decktape feature option from `node` to `version` so the value actually reaches the install script, which reads `VERSION`.
Fixes the uv installer URL so pinned versions resolve (`releases/download/<tag>/`) instead of only `latest`.
Remote installer downloads (uv, TinyTeX, Google signing key) now enforce HTTPS with TLS 1.2 and fail on HTTP errors, and the Chrome apt repository uses HTTPS.
Removes unused `USERNAME` resolution blocks and a leftover `VERSION` variable from feature scripts that never used them.
All touched scripts pass `shellcheck` and `shfmt -i 2 -ci`.