### PR TITLE
chore: sync duplicated dev container features and unpin python

### DIFF
--- a/.devcontainer/universal/devcontainer.json
+++ b/.devcontainer/universal/devcontainer.json
@@ -26,6 +26,7 @@
   "remoteUser": "codespace",
   "features": {
     "./quarto-computing-dependencies": {
+      "installOnPlatforms": "amd64",
       "rDeps": "rmarkdown,languageserver,prompt,lintr",
       "pythonDeps": "jupyter,papermill",
       "juliaDeps": "IJulia"

--- a/.devcontainer/universal/quarto-computing-dependencies/devcontainer-feature.json
+++ b/.devcontainer/universal/quarto-computing-dependencies/devcontainer-feature.json
@@ -34,7 +34,7 @@
       "installRMarkdown": "false"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.13.9",
+      "version": "latest",
       "enableShared": "true"
     },
     "ghcr.io/julialang/devcontainer-features/julia:1": {

--- a/.devcontainer/universal/quarto-computing-dependencies/devcontainer-feature.json
+++ b/.devcontainer/universal/quarto-computing-dependencies/devcontainer-feature.json
@@ -4,6 +4,11 @@
   "name": "Install Computing Dependencies for Quarto",
   "description": "Install R, Python, and Julia dependencies for Quarto.",
   "options": {
+    "installOnPlatforms": {
+      "type": "string",
+      "default": "amd64,arm64",
+      "description": "Comma-separated list of platforms on which to install dependencies."
+    },
     "rDeps": {
       "type": "string",
       "default": "rmarkdown",
@@ -29,7 +34,7 @@
       "installRMarkdown": "false"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "latest",
+      "version": "3.13.9",
       "enableShared": "true"
     },
     "ghcr.io/julialang/devcontainer-features/julia:1": {
@@ -37,6 +42,8 @@
     }
   },
   "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/devcontainers/features/git",
     "ghcr.io/rocker-org/devcontainer-features/r-rig",
     "ghcr.io/devcontainers/features/python",
     "ghcr.io/julialang/devcontainer-features/julia"

--- a/.devcontainer/universal/quarto-computing-dependencies/install.sh
+++ b/.devcontainer/universal/quarto-computing-dependencies/install.sh
@@ -6,6 +6,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
 
+PLATFORMS=${INSTALL_ON_PLATFORMS:-"amd64,arm64"}
+
 R_DEPS=${RDEPS:-"rmarkdown"}
 PYTHON_DEPS=${PYTHONDEPS:-"jupyter,papermill"}
 JULIA_DEPS=${JULIADEPS:-"IJulia"}
@@ -13,6 +15,12 @@ JULIA_DEPS=${JULIADEPS:-"IJulia"}
 if [ "$(id -u)" -ne 0 ]; then
   echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
   exit 1
+fi
+
+architecture="$(dpkg --print-architecture)"
+if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "arm64" ]; then
+  echo "(!) Architecture ${architecture} unsupported"
+  exit 2
 fi
 
 # Determine the appropriate non-root user
@@ -52,9 +60,15 @@ quarto_julia_deps() {
   su "${USERNAME}" -c "~/.juliaup/bin/julia -e 'using Pkg; Pkg.add.([\"${deps}\"])'"
 }
 
-apt-get update -y && apt-get install -y --no-install-recommends libuv1-dev && rm -rf /var/lib/apt/lists/*
-quarto_r_deps "${R_DEPS}"
-quarto_python_deps "${PYTHON_DEPS}"
-quarto_julia_deps "${JULIA_DEPS}"
+if [[ ",${PLATFORMS}," == *",${architecture},"* ]]; then
+  apt-get update -y && apt-get install -y --no-install-recommends libuv1-dev && rm -rf /var/lib/apt/lists/*
+  quarto_r_deps "${R_DEPS}"
+  quarto_python_deps "${PYTHON_DEPS}"
+  quarto_julia_deps "${JULIA_DEPS}"
+else
+  echo "(!) Skipping R, Python, and Julia dependencies for ${architecture} architecture"
+fi
 
 apt-get clean && rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/.devcontainer/universal/uv/devcontainer-feature.json
+++ b/.devcontainer/universal/uv/devcontainer-feature.json
@@ -11,5 +11,8 @@
       "type": "string"
     }
   },
-  "installsAfter": ["./quarto-computing-dependencies"]
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils",
+    "./quarto-computing-dependencies"
+  ]
 }

--- a/.devcontainer/universal/uv/install.sh
+++ b/.devcontainer/universal/uv/install.sh
@@ -11,6 +11,12 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
+architecture="$(dpkg --print-architecture)"
+if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "arm64" ]; then
+  echo "(!) Architecture ${architecture} unsupported"
+  exit 2
+fi
+
 apt_get_update() {
   if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
     echo "Running apt-get update..."
@@ -45,4 +51,7 @@ enable_autocompletion() {
 
 install_uv "${VERSION}"
 enable_autocompletion
+
 apt-get clean && rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/.github/.devcontainer/quarto-computing-dependencies/devcontainer-feature.json
+++ b/.github/.devcontainer/quarto-computing-dependencies/devcontainer-feature.json
@@ -34,7 +34,7 @@
       "installRMarkdown": "false"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.13.9",
+      "version": "latest",
       "enableShared": "true"
     },
     "ghcr.io/julialang/devcontainer-features/julia:1": {

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -17,9 +17,23 @@ permissions:
   packages: write
 
 jobs:
+  check-feature-sync:
+    runs-on: ubuntu-latest
+    name: Check - Duplicated features in sync
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Verify duplicated dev container features are identical
+        run: |
+          diff -r .github/.devcontainer/uv .devcontainer/universal/uv
+          diff -r .github/.devcontainer/quarto-computing-dependencies .devcontainer/universal/quarto-computing-dependencies
+
   build:
     runs-on: ubuntu-latest
     name: Build - Quarto ${{ matrix.QUARTO_VERSION }}
+    needs:
+      - "check-feature-sync"
     if: >-
       ! endsWith(github.event.pull_request.user.login, '[bot]') &&
         (


### PR DESCRIPTION
The uv and quarto-computing-dependencies features exist twice, in `.github/.devcontainer` (used by the published images) and `.devcontainer/universal`, and the copies had drifted: the universal copies were missing the platform gate, the architecture guard, and carried a different python version pin.

Symlinking the universal copies to the canonical ones was tried first and does not work: the devcontainer CLI fails with `Failed to fetch feature` when a local feature directory is a symlink, verified against a minimal fixture where the same build succeeds with a real directory. Instead the copies are now identical, and a `check-feature-sync` job diffs them so the build fails when they diverge again. The universal configuration keeps its amd64-only dependency install through the `installOnPlatforms` option it was previously getting by accident.

The python feature version returns to `latest` now that devcontainers/features#1501, which caused the pin, is fixed upstream.

Closes #54