### PR TITLE
ci: remove build status gate job

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -148,33 +148,6 @@ jobs:
           path: /tmp/quarto-check-outputs/${{ matrix.QUARTO_VERSION }}.txt
           retention-days: 1
 
-  # Keeps the "Build - Quarto release" and "Build - Quarto prerelease" status
-  # checks required by the repository ruleset, now that the build job names
-  # carry an architecture suffix. It reports on the whole build matrix, so a
-  # failure in either architecture of either version fails both checks.
-  build-status:
-    runs-on: ubuntu-latest
-    name: Build - Quarto ${{ matrix.QUARTO_VERSION }}
-
-    needs:
-      - "build"
-
-    if: always()
-
-    strategy:
-      matrix:
-        QUARTO_VERSION:
-          - release
-          - prerelease
-
-    steps:
-      - name: Report architecture build results
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
-        run: |
-          echo "Architecture builds: ${BUILD_RESULT}"
-          [ "${BUILD_RESULT}" = "success" ]
-
   merge:
     runs-on: ubuntu-latest
     name: Merge - Quarto ${{ matrix.QUARTO_VERSION }} manifests


### PR DESCRIPTION
The `build-status` job existed only to keep the `Build - Quarto release` and `Build - Quarto prerelease` status checks alive after the build jobs gained an architecture suffix, because the repository ruleset required those names.

It also reported a failure on bot pull requests. The build matrix is skipped there by design, the gate read that as a failed matrix, and the required check went red, which would have blocked the weekly README update pull request and any Dependabot pull request from auto-merging.

Requires the ruleset to list the per-architecture build jobs and the feature sync check instead:

```
Build - Quarto release (amd64)
Build - Quarto release (arm64)
Build - Quarto prerelease (amd64)
Build - Quarto prerelease (arm64)
Check - Duplicated features in sync
```