### PR TITLE
fix: configure the atelier format instead of replacing it

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -33,20 +33,20 @@ metadata-files:
 
 brand: _brand.yml
 
+# The `atelier` project type sets `format: atelier-html`. Declaring `html`
+# here would replace that format rather than configure it, silently dropping
+# the accessibility scripts, `lang: en-GB`, the colour-scheme handling, and
+# the extension stylesheet. The theme lists below extend the format's own,
+# which is why the project layer wins the cascade. They are written out twice
+# rather than shared through a YAML anchor, which the schema check rejects.
 format:
-  html:
-    # A project `theme` replaces the one contributed by the `atelier` project
-    # type rather than extending it, so the extension stylesheet is listed
-    # explicitly before the project layer. The two lists are written out
-    # rather than shared through a YAML anchor, which the schema check rejects.
+  atelier-html:
     theme:
       light:
         - brand
-        - _extensions/mcanouil/atelier/html/theme.scss
         - assets/stylesheets/theme.scss
       dark:
         - brand
-        - _extensions/mcanouil/atelier/html/theme.scss
         - assets/stylesheets/theme.scss
 
 filters:


### PR DESCRIPTION
The navbar tooltips never appeared, and none of the other `atelier` scripts did either.

`docs/_quarto.yml` declared `format: html`, which replaces the `atelier-html` format contributed by the project type rather than configuring it. Every `formats.html` contribution was dropped, with no warning at render time: the skip link, focus-ring and other accessibility fixes, the external-link treatment, the ordinal dates and the navbar tooltips were never injected, `lang` fell back to `en` from `en-GB`, and the extension stylesheet only came back because it was listed by an explicit path into `_extensions/`.

Declaring `atelier-html` restores all of it. The format supplies its own stylesheet again, so the hardcoded path can go, while the project stylesheet still comes last and wins the cascade.

Verified in the rendered output: all five scripts are injected, `lang="en-GB"`, the dark syntax-highlighting stylesheet is linked, tippy is loaded, and the colour-scheme toggle carries the `title` the tooltip binds to.